### PR TITLE
Fix invalid argument for some RSS Feeds

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -351,7 +351,7 @@ class Parser
         $guid = $item->get_item_tags('', 'guid');
         if ($guid && count($guid)) {
             $episode->setGuid($this->sanitize($guid[0]['data']));
-            if(count($guid[0]['attribs'][''])&&array_key_exists('isPermaLink',$guid[0]['attribs'][''])) {
+            if(isset($guid[0]['attribs'][''])&&count($guid[0]['attribs'][''])&&array_key_exists('isPermaLink',$guid[0]['attribs'][''])) {
                 $episode->setGuidIsPermalink($guid[0]['attribs']['']['isPermaLink']==='true');
             }
         }


### PR DESCRIPTION
Fix the error below 
count(): Argument #1 ($value) must be of type Countable|array, null given